### PR TITLE
feat: add forceCodeForRefreshToken prop

### DIFF
--- a/android/src/main/java/expo/modules/googlesignin/ExpoGoogleSigninModule.kt
+++ b/android/src/main/java/expo/modules/googlesignin/ExpoGoogleSigninModule.kt
@@ -70,7 +70,7 @@ class ExpoGoogleSigninModule : Module() {
             }
         }
 
-        AsyncFunction("signInAsync") { webClientId: String, scopes: List<String>?, promise: Promise ->
+        AsyncFunction("signInAsync") { webClientId: String, scopes: List<String>?, forceCodeForRefreshToken: Boolean?, promise: Promise ->
             val activity = appContext.currentActivity
             if (activity == null) {
                 promise.reject("ERR_NO_ACTIVITY", "No current activity", null)
@@ -92,6 +92,7 @@ class ExpoGoogleSigninModule : Module() {
                     googleSignInManager.handleAuthorization(
                         webClientId,
                         scopes,
+                        forceCodeForRefreshToken ?: false,
                         onPendingIntent = { pendingIntent ->
                             try {
                                 // Wrap the IntentSender in an IntentSenderRequest

--- a/android/src/main/java/expo/modules/googlesignin/GoogleSignInManager.kt
+++ b/android/src/main/java/expo/modules/googlesignin/GoogleSignInManager.kt
@@ -68,6 +68,7 @@ class GoogleSignInManager(private val context: Context) {
     fun handleAuthorization(
         clientId: String,
         scopes: List<String>?,
+        forceCodeForRefreshToken: Boolean,
         onPendingIntent: (PendingIntent) -> Unit,
         onAlreadyAuthorized: (String?) -> Unit,
         onError: (Exception) -> Unit
@@ -78,7 +79,7 @@ class GoogleSignInManager(private val context: Context) {
         )).map { Scope(it) }
 
         val authorizationRequest = AuthorizationRequest.Builder()
-            .requestOfflineAccess(clientId)
+            .requestOfflineAccess(clientId, forceCodeForRefreshToken)
             .setRequestedScopes(requestedScopes.toMutableList())
             .build()
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@madusha98/expo-google-signin",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Google sign in module for expo",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/ExpoGoogleSigninModule.ts
+++ b/src/ExpoGoogleSigninModule.ts
@@ -3,7 +3,7 @@ import { NativeModule, requireNativeModule } from 'expo';
 import {  ExpoGoogleSigninModuleEvents, SignInResult } from './ExpoGoogleSignin.types';
 
 declare class ExpoGoogleSigninModule extends NativeModule<ExpoGoogleSigninModuleEvents> {
-  signInAsync(webClientId: string, scopes?: string[]): Promise<SignInResult>;
+  signInAsync(webClientId: string, scopes?: string[], forceCodeForRefreshToken?: boolean): Promise<SignInResult>;
 }
 
 // This call loads the native module object from the JSI.


### PR DESCRIPTION
This PR introduces an optional forceCodeForRefreshToken parameter to the signInAsync function in the Expo Google Sign-In module. This allows consumers of the module to explicitly request a refresh token during authentication when using requestOfflineAccess.

Changes:
- Updated native Android function signatures to accept forceCodeForRefreshToken.
- Passed the new parameter to requestOfflineAccess() in AuthorizationRequest.Builder.
- Updated the TypeScript definitions to reflect the new optional argument.
- Bumped package version from 0.0.2 → 0.0.3.

This enhancement provides more control over token behavior during sign-in flows, especially useful in long-lived sessions or server-side token exchanges.