### PR TITLE
Remove android 14 Requirement

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,8 +43,9 @@ android {
 }
 
 dependencies {
-  implementation 'androidx.credentials:credentials:1.2.0'
+  implementation 'androidx.credentials:credentials:1.5.0'
   implementation 'com.google.android.libraries.identity.googleid:googleid:1.1.1'
-  implementation 'com.google.android.gms:play-services-auth:20.7.0'
+  implementation 'com.google.android.gms:play-services-auth:21.3.0'
   implementation 'androidx.activity:activity-compose:1.10.1'
+  implementation 'androidx.credentials:credentials-play-services-auth:1.5.0'
 }

--- a/android/src/main/java/expo/modules/googlesignin/ExpoGoogleSigninModule.kt
+++ b/android/src/main/java/expo/modules/googlesignin/ExpoGoogleSigninModule.kt
@@ -18,7 +18,6 @@ class ExpoGoogleSigninModule : Module() {
     private var signInPromise: Promise? = null
     private var authLauncher: androidx.activity.result.ActivityResultLauncher<IntentSenderRequest>? = null
 
-    @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
     override fun definition() = ModuleDefinition {
         Name("ExpoGoogleSignin")
 

--- a/android/src/main/java/expo/modules/googlesignin/ExpoGoogleSigninModule.kt
+++ b/android/src/main/java/expo/modules/googlesignin/ExpoGoogleSigninModule.kt
@@ -1,10 +1,8 @@
 package expo.modules.googlesignin
 
 import android.app.Activity
-import android.os.Build
 import android.util.Log
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.annotation.RequiresApi
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@madusha98/expo-google-signin",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Google sign in module for expo",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
- add required libraries to run credential manager on android versions below 14
- remove android 14 requirement
- upgrade dependencies